### PR TITLE
Add a builder derive macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,8 @@ name = "eiga"
 version = "0.1.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+eiga_builder_derive = { path = "eiga_builder_derive" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 ureq = { version = "2.4.0", features = ["json"] }

--- a/eiga_builder_derive/.gitignore
+++ b/eiga_builder_derive/.gitignore
@@ -1,0 +1,4 @@
+/target
+Cargo.lock
+
+.env

--- a/eiga_builder_derive/.rustfmt.toml
+++ b/eiga_builder_derive/.rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 79

--- a/eiga_builder_derive/Cargo.toml
+++ b/eiga_builder_derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "eiga_builder_derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "1.0"

--- a/eiga_builder_derive/src/lib.rs
+++ b/eiga_builder_derive/src/lib.rs
@@ -1,0 +1,332 @@
+//! A macro that implements a builder for a struct.
+//!
+//! This was designed to be used by `eiga`, and thus makes a few assumptions:
+//! - The target struct has named fields
+//! - Optional fields have their type written as `Option<...>`. The macro won't
+//! recognize the `Option` type in any other form, e.g., `std::option::Option`.
+//!
+//! # Example
+//!
+//! Applying #[derive(Builder)] to
+//!
+//! ```
+//! # use eiga_builder_derive::Builder;
+//!
+//! #[derive(Builder)]
+//! struct Foo<'a> {
+//!     x: i32,
+//!     y: Option<&'a str>,
+//! }
+//! ```
+//!
+//! generates
+//!
+//! ```
+//! # struct Foo<'a> {
+//! #     x: i32,
+//! #     y: Option<&'a str>,
+//! # }
+//!
+//! /// A builder for `Foo`.
+//! struct FooBuilder<'a> {
+//!     x: i32,
+//!     y: Option<&'a str>,
+//! }
+//!
+//! impl<'a> FooBuilder<'a> {
+//!     fn new(x: i32) -> Self {
+//!         Self {
+//!             x,
+//!             y: None,
+//!         }
+//!     }
+//!
+//!     /// Builds a new `Foo` based on the current configuration.
+//!     pub fn build(&self) -> Foo<'a> {
+//!         Foo {
+//!             x: self.x,
+//!             y: self.y
+//!         }
+//!     }
+//!
+//!     /// Sets the y query string parameter.
+//!     pub fn y(&mut self, y: &'a str) -> &mut Self {
+//!         self.y = Some(y);
+//!
+//!         self
+//!     }
+//! }
+//!
+//! impl<'a> Foo<'a> {
+//!     /// Constructs a new `FooBuilder`.
+//!     pub fn builder(x: i32) -> FooBuilder<'a> {
+//!         FooBuilder::new(x)
+//!     }
+//! }
+//! ```
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use syn::{
+    parse_macro_input, Data, DeriveInput, Field, Fields, GenericArgument,
+    Generics, PathArguments, Type,
+};
+
+#[doc(hidden)]
+#[proc_macro_derive(Builder)]
+pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let ident = &input.ident;
+    let builder_ident = &format_ident!("{}Builder", ident);
+    let generics = &input.generics;
+    let struct_data = &input.data;
+
+    let builder_struct =
+        builder_struct(ident, builder_ident, generics, struct_data);
+    let builder_impl =
+        builder_impl(ident, builder_ident, generics, struct_data);
+    let builder_method =
+        builder_method(ident, builder_ident, generics, struct_data);
+
+    let tokens = quote! {
+        #builder_struct
+        #builder_impl
+        #builder_method
+    };
+
+    tokens.into()
+}
+
+/// Returns a token stream of the builder struct definition.
+fn builder_struct(
+    ident: &Ident,
+    builder_ident: &Ident,
+    generics: &Generics,
+    struct_data: &Data,
+) -> TokenStream {
+    let comment = format!("A builder for `{}`", ident);
+
+    let builder_fields_iter = fields_iter(struct_data).map(|field| {
+        let ident = &field.ident;
+        let ty = &field.ty;
+
+        quote! { #ident: #ty }
+    });
+    let builder_fields = quote! { #(#builder_fields_iter),* };
+
+    quote! {
+        #[doc = #comment]
+        pub struct #builder_ident #generics {
+            #builder_fields
+        }
+    }
+}
+
+/// Returns a token stream of the builder struct implementation.
+fn builder_impl(
+    ident: &Ident,
+    builder_ident: &Ident,
+    generics: &Generics,
+    struct_data: &Data,
+) -> TokenStream {
+    let new_method = new_method(struct_data);
+    let build_method = build_method(ident, generics, struct_data);
+    let setters = setters(struct_data);
+
+    quote! {
+        impl #generics #builder_ident #generics {
+            #new_method
+            #build_method
+            #setters
+        }
+    }
+}
+
+/// Returns a token stream of the builder's `new` associated method.
+fn new_method(struct_data: &Data) -> TokenStream {
+    let required_parameters_iter =
+        required_fields_iter(struct_data).map(|field| {
+            let ident = &field.ident;
+            let ty = &field.ty;
+
+            quote! { #ident: #ty }
+        });
+    let required_parameters = quote! { #(#required_parameters_iter),* };
+
+    let fields_iter = fields_iter(struct_data).map(|field| {
+        let ident = &field.ident;
+
+        if is_option(&field.ty) {
+            quote! { #ident: None }
+        } else {
+            quote! { #ident }
+        }
+    });
+    let fields = quote! { #(#fields_iter),* };
+
+    quote! {
+        fn new(#required_parameters) -> Self {
+            Self {
+                #fields
+            }
+        }
+    }
+}
+
+/// Returns a token stream of the builder's `build` method.
+fn build_method(
+    ident: &Ident,
+    generics: &Generics,
+    struct_data: &Data,
+) -> TokenStream {
+    let comment = format!(
+        "Builds a new `{}` based on the current configuration.",
+        ident
+    );
+
+    let fields_iter = fields_iter(struct_data).map(|field| {
+        let ident = &field.ident;
+
+        quote! { #ident: self.#ident }
+    });
+    let fields = quote! { #(#fields_iter),* };
+
+    quote! {
+        #[doc = #comment]
+        pub fn build(&self) -> #ident #generics {
+            #ident {
+                #fields
+            }
+        }
+    }
+}
+
+/// Returns a token stream of the builder's setter methods.
+///
+/// There's a setter for each optional field on the original struct.
+fn setters(data: &Data) -> TokenStream {
+    let setters_iter = optional_fields_iter(data).map(|field| {
+        // It's safe to unwrap here since optional_fields_iter iterates over
+        // named fields only.
+        let ident = field.ident.as_ref().unwrap();
+        let comment = format!("Sets the {} query string parameter.", ident);
+        let ty = inner_type(&field.ty);
+
+        quote! {
+            #[doc = #comment]
+            pub fn #ident(&mut self, #ident: #ty) -> &mut Self {
+                self.#ident = Some(#ident);
+
+                self
+            }
+        }
+    });
+
+    quote! { #(#setters_iter)* }
+}
+
+/// Returns a token stream of the original struct's `builder` method.
+fn builder_method(
+    ident: &Ident,
+    builder_ident: &Ident,
+    generics: &Generics,
+    struct_data: &Data,
+) -> TokenStream {
+    let comment = format!("Constructs a new `{}`.", builder_ident);
+
+    let parameters_iter = required_fields_iter(struct_data).map(|field| {
+        let ident = &field.ident;
+        let ty = &field.ty;
+
+        quote! { #ident: #ty }
+    });
+    let parameters = quote! { #(#parameters_iter),* };
+
+    let arguments_iter = required_fields_iter(struct_data).map(|field| {
+        let ident = &field.ident;
+
+        quote! { #ident }
+    });
+    let arguments = quote! { #(#arguments_iter),* };
+
+    quote! {
+        impl #generics #ident #generics {
+            #[doc = #comment]
+            pub fn builder(#parameters) -> #builder_ident #generics {
+                #builder_ident::new(#arguments)
+            }
+        }
+    }
+}
+
+/// Returns the first generic type argument of a type.
+///
+/// This function was written for extracting the inner type from an `Option`.
+/// I wouldn't expect it work for other use cases.
+///
+/// # Panics
+///
+/// Panics if `ty` is not a type path or a generic type.
+fn inner_type(ty: &Type) -> &Type {
+    let first_type_path_segment = match ty {
+        Type::Path(type_path) => match type_path.path.segments.first() {
+            Some(path_segment) => path_segment,
+            None => unimplemented!(),
+        },
+        _ => unimplemented!(),
+    };
+
+    match &first_type_path_segment.arguments {
+        PathArguments::AngleBracketed(arguments) => {
+            match arguments.args.first() {
+                Some(GenericArgument::Type(ty)) => ty,
+                _ => unimplemented!(),
+            }
+        }
+        _ => unimplemented!(),
+    }
+}
+
+/// Returns true if `ty` is an `Option`.
+///
+/// This function returns true if and only if the type is literally written as
+/// `Option<...>`. This approach is brittle, but it works for `eiga`.
+fn is_option(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => match type_path.path.segments.first() {
+            Some(segment) => segment.ident == "Option",
+            None => false,
+        },
+        _ => false,
+    }
+}
+
+/// Returns an iterator over the named fields of a struct.
+///
+/// # Panics
+///
+/// Panics if `struct_data` doesn't represent a struct with named fields.
+fn fields_iter(struct_data: &Data) -> impl Iterator<Item = &Field> {
+    match struct_data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => fields.named.iter(),
+            _ => unimplemented!(),
+        },
+        _ => unimplemented!(),
+    }
+}
+
+/// Returns an iterator over the optional fields of a struct.
+///
+/// An optional field is a field of type `Option`.
+fn optional_fields_iter(struct_data: &Data) -> impl Iterator<Item = &Field> {
+    fields_iter(struct_data).filter(|field| is_option(&field.ty))
+}
+
+/// Returns an iterator over the required fields of a struct.
+///
+/// A required field is a field whose type is not `Option`.
+fn required_fields_iter(struct_data: &Data) -> impl Iterator<Item = &Field> {
+    fields_iter(struct_data).filter(|field| !is_option(&field.ty))
+}

--- a/src/api/movie/details.rs
+++ b/src/api/movie/details.rs
@@ -1,47 +1,16 @@
 use std::borrow::Cow;
 
+use eiga_builder_derive::Builder;
+
 use crate::endpoint::Endpoint;
 use crate::http::Method;
 use crate::query::QueryParameters;
 
-/// A builder for `Details`.
-pub struct DetailsBuilder<'a> {
-    id: u32,
-    language: Option<&'a str>,
-}
-
-impl<'a> DetailsBuilder<'a> {
-    fn new(id: u32) -> DetailsBuilder<'a> {
-        DetailsBuilder { id, language: None }
-    }
-
-    /// Builds a new `Details` based on the current configuration.
-    pub fn build(&self) -> Details<'a> {
-        Details {
-            id: self.id,
-            language: self.language,
-        }
-    }
-
-    /// Sets the language query string parameter.
-    pub fn language(&mut self, language: &'a str) -> &mut DetailsBuilder<'a> {
-        self.language = Some(language);
-
-        self
-    }
-}
-
 /// The movie details endpoint.
+#[derive(Builder)]
 pub struct Details<'a> {
     id: u32,
     language: Option<&'a str>,
-}
-
-impl<'a> Details<'a> {
-    /// Constructs a new `DetailsBuilder` from the given movie ID.
-    pub fn builder(id: u32) -> DetailsBuilder<'a> {
-        DetailsBuilder::new(id)
-    }
 }
 
 impl<'a> Endpoint for Details<'a> {

--- a/src/api/search/movies.rs
+++ b/src/api/search/movies.rs
@@ -1,96 +1,13 @@
 use std::borrow::Cow;
 
+use eiga_builder_derive::Builder;
+
 use crate::endpoint::Endpoint;
 use crate::http::Method;
 use crate::query::QueryParameters;
 
-/// A builder for `Movies`.
-pub struct MoviesBuilder<'a> {
-    query: &'a str,
-    language: Option<&'a str>,
-    page: Option<u64>,
-    include_adult: Option<bool>,
-    region: Option<&'a str>,
-    year: Option<u64>,
-    primary_release_year: Option<u64>,
-}
-
-impl<'a> MoviesBuilder<'a> {
-    fn new(query: &'a str) -> MoviesBuilder<'a> {
-        MoviesBuilder {
-            query,
-            language: None,
-            page: None,
-            include_adult: None,
-            region: None,
-            year: None,
-            primary_release_year: None,
-        }
-    }
-
-    /// Builds a new `Movies` based on the current configuration.
-    pub fn build(&self) -> Movies<'a> {
-        Movies {
-            query: self.query,
-            language: self.language,
-            page: self.page,
-            include_adult: self.include_adult,
-            region: self.region,
-            year: self.year,
-            primary_release_year: self.primary_release_year,
-        }
-    }
-
-    /// Sets the language query string parameter.
-    pub fn language(&mut self, language: &'a str) -> &mut MoviesBuilder<'a> {
-        self.language = Some(language);
-
-        self
-    }
-
-    /// Sets the page query string parameter.
-    pub fn page(&mut self, page: u64) -> &mut MoviesBuilder<'a> {
-        self.page = Some(page);
-
-        self
-    }
-
-    /// Sets the include_adult query string parameter.
-    pub fn include_adult(
-        &mut self,
-        include_adult: bool,
-    ) -> &mut MoviesBuilder<'a> {
-        self.include_adult = Some(include_adult);
-
-        self
-    }
-
-    /// Sets the region query string parameter.
-    pub fn region(&mut self, region: &'a str) -> &mut MoviesBuilder<'a> {
-        self.region = Some(region);
-
-        self
-    }
-
-    /// Sets the year query string parameter.
-    pub fn year(&mut self, year: u64) -> &mut MoviesBuilder<'a> {
-        self.year = Some(year);
-
-        self
-    }
-
-    /// Sets the primary_release_year query string parameter.
-    pub fn primary_release_year(
-        &mut self,
-        primary_release_year: u64,
-    ) -> &mut MoviesBuilder<'a> {
-        self.primary_release_year = Some(primary_release_year);
-
-        self
-    }
-}
-
 /// The search movies endpoint.
+#[derive(Builder)]
 pub struct Movies<'a> {
     query: &'a str,
     language: Option<&'a str>,
@@ -99,13 +16,6 @@ pub struct Movies<'a> {
     region: Option<&'a str>,
     year: Option<u64>,
     primary_release_year: Option<u64>,
-}
-
-impl<'a> Movies<'a> {
-    /// Constructs a new `DetailsBuilder` from the given movie ID.
-    pub fn builder(query: &'a str) -> MoviesBuilder<'a> {
-        MoviesBuilder::new(query)
-    }
 }
 
 impl<'a> Endpoint for Movies<'a> {


### PR DESCRIPTION
There's a lot of similar code that implements a builder for each endpoint struct. A macro cuts out the duplicate code, and it should make adding new endpoints faster. The macro is not robust by any means, but it works for the intended usage in `eiga`.