### PR TITLE
Remove the release flag from commands in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --release
+        run: cargo build
       - name: Test
-        run: cargo test --release
+        run: cargo test


### PR DESCRIPTION
The release flag is unnecessary, and it causes the build to take longer.