### PR TITLE
Add an iterator for pageable endpoints, and improve tests

### DIFF
--- a/JUSTFILE
+++ b/JUSTFILE
@@ -1,0 +1,10 @@
+set dotenv-load
+
+default:
+    just --list
+
+test:
+    cargo test --test it
+
+example name:
+    cargo run --example {{name}}

--- a/examples/manual_paging.rs
+++ b/examples/manual_paging.rs
@@ -22,7 +22,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     // where you want to manually send a request to a pageable endpoint.
     let page: Page<MovieResult> = tmdb.send(&search_movies_endpoint)?;
 
-    assert!(page.is_last_page());
     // Iterate over the results to see if they contain the 1962 version of
     // "Black Lizard."
     assert!(page.results.iter().any(|result| {

--- a/examples/paging.rs
+++ b/examples/paging.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::error;
+
+use serde::Deserialize;
+
+use eiga::{search, Client, Tmdb};
+
+#[derive(Deserialize)]
+struct MovieResult {
+    release_date: String,
+    title: String,
+}
+
+fn main() -> Result<(), Box<dyn error::Error>> {
+    let token = env::var("TMDB_TOKEN")?;
+    let tmdb = Tmdb::new(token);
+
+    let search_movies_endpoint =
+        search::Movies::builder("Black Lizard").build();
+
+    let page_iter = tmdb.page(&search_movies_endpoint);
+
+    let _: Result<Vec<MovieResult>, eiga::Error> = page_iter.collect();
+
+    Ok(())
+}

--- a/examples/paging.rs
+++ b/examples/paging.rs
@@ -15,12 +15,17 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let token = env::var("TMDB_TOKEN")?;
     let tmdb = Tmdb::new(token);
 
-    let search_movies_endpoint =
-        search::Movies::builder("Black Lizard").build();
+    let search_movies_endpoint = search::Movies::builder("Ringu").build();
 
+    // `page` returns an iterator over the results of a pageable endpoint.
     let page_iter = tmdb.page(&search_movies_endpoint);
 
-    let _: Result<Vec<MovieResult>, eiga::Error> = page_iter.collect();
+    // Print out the first five results for the search query "Ringu."
+    page_iter.take(5).filter_map(|result| result.ok()).for_each(
+        |result: MovieResult| {
+            println!("{} ({})", result.title, result.release_date)
+        },
+    );
 
     Ok(())
 }

--- a/src/api/search/movies.rs
+++ b/src/api/search/movies.rs
@@ -39,4 +39,8 @@ impl<'a> Endpoint for Movies<'a> {
     }
 }
 
-impl<'a> Pageable for Movies<'a> {}
+impl<'a> Pageable for Movies<'a> {
+    fn page(&self) -> Option<u64> {
+        self.page
+    }
+}

--- a/src/api/search/movies.rs
+++ b/src/api/search/movies.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use eiga_builder_derive::Builder;
 use http::Method;
 
-use crate::{Endpoint, QueryParameters};
+use crate::{Endpoint, Pageable, QueryParameters};
 
 /// The search movies endpoint.
 #[derive(Builder)]
@@ -38,3 +38,5 @@ impl<'a> Endpoint for Movies<'a> {
         parameters
     }
 }
+
+impl<'a> Pageable for Movies<'a> {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use serde::de::DeserializeOwned;
 
-use crate::{Endpoint, Error};
+use crate::{Endpoint, Error, PageIter, Pageable};
 
 /// A trait for objects that send requests.
 ///
@@ -39,4 +39,9 @@ pub trait Client {
     fn ignore<E>(&self, endpoint: &E) -> Result<(), Error>
     where
         E: Endpoint;
+
+    fn page<'a, E, D>(&'a self, endpoint: &'a E) -> PageIter<'a, Self, E, D>
+    where
+        E: Pageable,
+        D: DeserializeOwned;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,6 @@ pub use api::*;
 pub use client::Client;
 pub use endpoint::Endpoint;
 pub use error::Error;
-pub use page::Page;
+pub use page::{Page, PageIter, Pageable};
 pub use query_parameters::QueryParameters;
 pub use tmdb::Tmdb;

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,5 +1,7 @@
 use serde::{de::DeserializeOwned, Deserialize};
 
+use crate::{Client, Endpoint, Error};
+
 /// The response type of pageable endpoints.
 #[derive(Deserialize)]
 pub struct Page<T> {
@@ -16,5 +18,47 @@ where
     /// Returns `true` if this is the last page of a search query.
     pub fn is_last_page(&self) -> bool {
         self.page == self.total_pages
+    }
+}
+
+pub trait Pageable: Endpoint {}
+
+pub struct PageIter<'a, C, E, T>
+where
+    C: ?Sized,
+{
+    client: &'a C,
+    endpoint: &'a E,
+    results: Vec<T>,
+}
+
+impl<'a, C, E, D> PageIter<'a, C, E, D>
+where
+    C: Client,
+    E: Pageable,
+    D: DeserializeOwned,
+{
+    pub(crate) fn new(
+        client: &'a C,
+        endpoint: &'a E,
+    ) -> PageIter<'a, C, E, D> {
+        PageIter {
+            client,
+            endpoint,
+            results: Vec::new(),
+        }
+    }
+}
+
+impl<'a, C, E, D> Iterator for PageIter<'a, C, E, D>
+where
+    C: Client,
+    E: Pageable,
+    D: DeserializeOwned,
+{
+    type Item = Result<D, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
     }
 }

--- a/src/tmdb.rs
+++ b/src/tmdb.rs
@@ -7,7 +7,7 @@ use ureq::{
 };
 use url::Url;
 
-use crate::{Client, Endpoint, Error};
+use crate::{Client, Endpoint, Error, PageIter, Pageable};
 
 const TMDB_BASE_URL: &str = "https://api.themoviedb.org/3/";
 
@@ -142,5 +142,13 @@ impl Client for Tmdb {
         self.call(endpoint)?;
 
         Ok(())
+    }
+
+    fn page<'a, E, D>(&'a self, endpoint: &'a E) -> PageIter<'a, Self, E, D>
+    where
+        E: Pageable,
+        D: DeserializeOwned,
+    {
+        PageIter::new(self, endpoint)
     }
 }

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -2,7 +2,7 @@ use httpmock::prelude::*;
 use httpmock::Mock;
 use serde::de::DeserializeOwned;
 
-use eiga::{movie, search, Client, Endpoint, Tmdb};
+use eiga::{movie, search, Client, Endpoint, PageIter, Pageable, Tmdb};
 
 /// A builder for `TestClient`.
 struct TestClientBuilder<'a> {
@@ -115,6 +115,14 @@ impl<'a> Client for TestClient<'a> {
         mock.delete();
 
         Ok(())
+    }
+
+    fn page<'b, E, D>(&'b self, endpoint: &'b E) -> PageIter<'b, Self, E, D>
+    where
+        E: Pageable,
+        D: DeserializeOwned,
+    {
+        todo!()
     }
 }
 


### PR DESCRIPTION
Follow-up tasks for paging:
- Users should be able to limit the number of pages/requests
- Tests