### PR TITLE
Use the builder lite pattern for constructing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let token = env::var("TMDB_TOKEN")?;
     let tmdb = Tmdb::new(token);
 
-    // Build an endpoint to fetch details about "Tokyo Drifter" (1966).
+    // Build an endpoint to fetch details about "Tokyo Drifter" (1966). Each
+    // endpoint has setter methods to set optional query string parameters.
     let tokyo_drifter_id = 45706;
-    let movie_details_endpoint = movie::Details::builder(tokyo_drifter_id)
-        .language("en-US")
-        .build();
+    let movie_details_endpoint =
+        movie::Details::new(tokyo_drifter_id).language("en-US");
 
     // Send the request! Type annotations are required because `send` can
     // deserialize the response to any type that implements `Deserialize`.

--- a/eiga_builder_derive/Cargo.toml
+++ b/eiga_builder_derive/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Zach Madsen <zachcmadsen@gmail.com>"]
 license = "MIT"
 description = "A builder derive macro for the `eiga` crate"
+documentation = "https://docs.rs/eiga_builder_derive"
 repository = "https://github.com/zachcmadsen/eiga"
 
 [lib]

--- a/eiga_builder_derive/src/lib.rs
+++ b/eiga_builder_derive/src/lib.rs
@@ -3,10 +3,10 @@
 //! pattern.
 //!
 //! Since this was designed to be used by `eiga`, it makes some assumptions:
-//! - The target struct has named fields
+//! - The target struct has named fields.
 //! - Optional fields have their type written as `Option<...>`. The macro won't
-//! recognize the `Option` type in any other form, e.g., `std::option::Option`
-//! - Optional fields represent query string parameters
+//! recognize the `Option` type in any other form, e.g., `std::option::Option`.
+//! - Optional fields represent query string parameters.
 //!
 //! # Example
 //!

--- a/examples/get_movie_details.rs
+++ b/examples/get_movie_details.rs
@@ -19,11 +19,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let token = env::var("TMDB_TOKEN")?;
     let tmdb = Tmdb::new(token);
 
-    // Build an endpoint to fetch details about "Tokyo Drifter" (1966).
+    // Build an endpoint to fetch details about "Tokyo Drifter" (1966). Each
+    // endpoint has setter methods to set optional query string parameters.
     let tokyo_drifter_id = 45706;
-    let movie_details_endpoint = movie::Details::builder(tokyo_drifter_id)
-        .language("en-US")
-        .build();
+    let movie_details_endpoint =
+        movie::Details::new(tokyo_drifter_id).language("en-US");
 
     // Send the request! Type annotations are required because `send` can
     // deserialize the response to any type that implements `Deserialize`.

--- a/examples/manual_paging.rs
+++ b/examples/manual_paging.rs
@@ -15,8 +15,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let token = env::var("TMDB_TOKEN")?;
     let tmdb = Tmdb::new(token);
 
-    let search_movies_endpoint =
-        search::Movies::builder("Black Lizard").build();
+    let search_movies_endpoint = search::Movies::new("Black Lizard");
 
     // For convenience, eiga provides a `Page` type. This is handy for cases
     // where you want to manually send a request to a pageable endpoint.

--- a/examples/paging.rs
+++ b/examples/paging.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let token = env::var("TMDB_TOKEN")?;
     let tmdb = Tmdb::new(token);
 
-    let search_movies_endpoint = search::Movies::builder("Ringu").build();
+    let search_movies_endpoint = search::Movies::new("Ringu");
 
     // `page` returns an iterator over the results of a pageable endpoint.
     let page_iter = tmdb.page(&search_movies_endpoint);

--- a/src/api/search/movies.rs
+++ b/src/api/search/movies.rs
@@ -40,7 +40,7 @@ impl<'a> Endpoint for Movies<'a> {
 }
 
 impl<'a> Pageable for Movies<'a> {
-    fn page(&self) -> Option<u64> {
+    fn initial_page(&self) -> Option<u64> {
         self.page
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,31 +5,13 @@ use crate::{Endpoint, Error, PageIter, Pageable};
 /// A trait for objects that send requests.
 ///
 /// Implementors of `Client`, or clients, are defined by three methods, `send`,
-/// and `ignore`:
+/// `ignore`, and `page`:
 /// - `send` sends a request to the given endpoint and returns the deserialized
 /// response body.
 /// - `ignore` sends a request to the given endpoint without deserializing the
 /// response body.
-///
-/// # Example
-///
-/// ```no_run
-/// use eiga::{search, Client, Tmdb};
-///
-/// fn main() -> Result<(), eiga::Error> {
-///     // Create a `Tmdb` client.
-///     let tmdb = Tmdb::new("<token>");
-///     
-///     // Build an endpoint to search for the movie Pale Flower.
-///     let search_movies_endpoint =
-///         search::Movies::builder("Pale Flower").build();
-///     
-///     // Send a request to the endpoint using the client.
-///     tmdb.ignore(&search_movies_endpoint)?;
-///
-///     Ok(())
-/// }
-/// ```
+/// - `page` returns an iterator over the results of the given pageable
+/// endpoint.
 pub trait Client {
     fn send<E, D>(&self, endpoint: &E) -> Result<D, Error>
     where

--- a/src/page.rs
+++ b/src/page.rs
@@ -24,7 +24,7 @@ where
 }
 
 pub trait Pageable: Endpoint {
-    fn page(&self) -> Option<u64>;
+    fn initial_page(&self) -> Option<u64>;
 }
 
 struct PageIterState<'a, C, E>
@@ -45,7 +45,7 @@ where
         PageIterState {
             client,
             endpoint,
-            next_page: endpoint.page().or(Some(1)),
+            next_page: endpoint.initial_page().or(Some(1)),
         }
     }
 }

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -142,7 +142,7 @@ impl<'a> Client for TestClient<'a> {
         Ok(())
     }
 
-    fn page<'b, E, D>(&'b self, endpoint: &'b E) -> PageIter<'b, Self, E, D>
+    fn page<'b, E, D>(&'b self, _: &'b E) -> PageIter<'b, Self, E, D>
     where
         E: Pageable,
         D: DeserializeOwned,
@@ -202,7 +202,7 @@ fn unprocessable_entity() {
         .build();
 
     let search_movies_endpoint =
-        search::Movies::builder("Cruel Gun Story").page(600).build();
+        search::Movies::new("Cruel Gun Story").page(600);
 
     check_err(
         test_client,
@@ -224,7 +224,7 @@ fn not_found() {
         .response(json!({"success":false, "status_code":34, "status_message": expected_message}))
         .build();
 
-    let movie_details_endpoint = movie::Details::builder(115572).build();
+    let movie_details_endpoint = movie::Details::new(115572);
 
     check_err(
         test_client,
@@ -242,8 +242,7 @@ fn get_movie_details() {
         .parameters(&[("language", "en-US")])
         .build();
 
-    let movie_details_endpoint =
-        movie::Details::builder(500).language("en-US").build();
+    let movie_details_endpoint = movie::Details::new(500).language("en-US");
 
     check(test_client, movie_details_endpoint);
 }
@@ -257,7 +256,7 @@ fn get_movie_alternative_titles() {
         .build();
 
     let movie_alternative_titles_endpoint =
-        movie::AlternativeTitles::builder(500).country("US").build();
+        movie::AlternativeTitles::new(500).country("US");
 
     check(test_client, movie_alternative_titles_endpoint);
 }
@@ -270,8 +269,7 @@ fn get_movie_credits() {
         .parameters(&[("language", "en-US")])
         .build();
 
-    let movie_credits_endpoint =
-        movie::Credits::builder(500).language("en-US").build();
+    let movie_credits_endpoint = movie::Credits::new(500).language("en-US");
 
     check(test_client, movie_credits_endpoint);
 }
@@ -291,14 +289,13 @@ fn search_movies() {
         ])
         .build();
 
-    let search_movies_endpoint = search::Movies::builder("Samurai Spy")
+    let search_movies_endpoint = search::Movies::new("Samurai Spy")
         .language("en-US")
         .page(1)
         .include_adult(false)
         .region("US")
         .year(1965)
-        .primary_release_year(1965)
-        .build();
+        .primary_release_year(1965);
 
     check(test_client, search_movies_endpoint);
 }


### PR DESCRIPTION
Since an endpoint can't be in an invalid state[^1], it seemed unnecessary to have a separate builder type. The builder derive macro now implements the [builder lite](https://matklad.github.io/2022/05/29/builder-lite.html) pattern.

[^1]: Users can provide "incorrect" values for query string parameters. For example, a user could set the region parameter to `"ABC"`. That isn't a valid ISO 3166-1 code, but it's still valid to send it to the API. At this point, I don't want to consider the endpoint object as invalid. The caller just provided a bad value, and the API response should tell them how to fix it. There are improvements to prevent incorrect values, e.g., accept an enum when setting the region parameter. Those changes can come later though.